### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/dshell-defcon/docker/Dockerfile
+++ b/dshell-defcon/docker/Dockerfile
@@ -18,10 +18,10 @@ RUN git clone https://github.com/USArmyResearchLab/Dshell.git
 
 # download and gunzip GeoIP files
 WORKDIR /opt/Dshell/share/GeoIP/
-RUN wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
-RUN wget http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
-RUN wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
-RUN wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
+RUN wget https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
+RUN wget https://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
+RUN wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+RUN wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
 RUN gunzip *.gz
 
 # make Dshell


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).